### PR TITLE
fix: Fix apache-kamelet-catalog E2E test

### DIFF
--- a/e2e/yaks/common/apache-kamelet-catalog/yaks-config.yaml
+++ b/e2e/yaks/common/apache-kamelet-catalog/yaks-config.yaml
@@ -23,4 +23,6 @@ pre:
   run: |
     kamel install -w -n $YAKS_NAMESPACE
 
+    kubectl wait kamelets.camel.apache.org/timer-source --for=condition=Ready --timeout=120s -n $YAKS_NAMESPACE
+
     kamel run logger.groovy -w -n $YAKS_NAMESPACE


### PR DESCRIPTION
Explicitly wait for timer-source Kamelet to be ready before starting the test integration